### PR TITLE
Fix: "autoreconf --install" error about subdir-objects

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,4 @@
+AUTOMAKE_OPTIONS = subdir-objects
 ACLOCAL_AMFLAGS = -I m4
 sbin_PROGRAMS = \
 		client \

--- a/src/md5-buildin/Makefile.am
+++ b/src/md5-buildin/Makefile.am
@@ -1,3 +1,4 @@
+AUTOMAKE_OPTIONS = subdir-objects
 bin_PROGRAMS = md5test \
 		$(NULL)
 md5test_SOURCES = md5test.c \


### PR DESCRIPTION
从automake更新到1.14.1开始，需要在autoconf的配置中加上 subdir-objects 选项才能顺利编译。
不然 autoreconf --install 会报错。

From the automake-1.14.1 NEWS file:

The next major Automake version (2.0) will unconditionally activate
the 'subdir-objects' option.  In order to smooth out the transition,
we now give a warning (in the category 'unsupported') whenever a
source file is present in a subdirectory but the 'subdir-object' is
not enabled.  For example, the following usage will trigger such a
warning:

```
    bin_PROGRAMS = sub/foo
    sub_foo_SOURCES = sub/main.c sub/bar.c
```

ref： #13
ref: http://stackoverflow.com/questions/21609580/autotools-build-fails-due-to-subdir-objects-option-in-am-init-automake (所以我觉得修改 Makefile.am 兼容性更好一些)
